### PR TITLE
Add RDS Postgres db credentials (read from Kube secrets) as environme…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 # Created by .ignore support plugin (hsz.mobi)
+.idea/

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -145,7 +145,37 @@ spec:
           - name: SERVER_PORT
             value: '8080'
           - name: ENDPOINTS_INFO_ENABLED
-            value: 'false'  
+            value: 'false'
+          - name: PTTG_DB_HOSTNAME
+            valueFrom:
+              secretKeyRef:
+                name: pttg-rds-access
+                key: endpoint
+          - name: PTTG_DB_PORT
+            valueFrom:
+              secretKeyRef:
+                name: pttg-rds-access
+                key: port
+          - name: PTTG_DB_NAME
+            valueFrom:
+              secretKeyRef:
+                name: pttg-rds-access
+                key: database
+          - name: IP_SCHEMA_NAME
+            valueFrom:
+              secretKeyRef:
+                name: db-secrets
+                key: schema_name
+          - name: IP_DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: db-secrets
+                key: application_username
+          - name: IP_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: db-secrets
+                key: application_password
           - name: BASE_HMRC_URL
             valueFrom:
               configMapKeyRef:
@@ -155,6 +185,14 @@ spec:
             value: 'https://pttg-ip-hmrc-access-code.pt-i-{{.ENVIRONMENT}}.svc.cluster.local'
           - name: JDK_TRUST_FILE
             value: '/data/truststore.jks'
+          - name: AUDITING_DEPLOYMENT_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: AUDITING_DEPLOYMENT_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         resources:
           limits:
             cpu: 1600m


### PR DESCRIPTION
…nt variables, for use by Audit. This config can be removed when we transition to using an independent Audit component.