### PR TITLE
EE-17546 Add SA Maximum History

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -76,7 +76,7 @@ spec:
             - name: bundle
               mountPath: /etc/ssl/certs
               readOnly: true
-  
+
         - name: proxy
           image: quay.io/ukhomeofficedigital/nginx-proxy:v3.2.9
           imagePullPolicy: Always
@@ -239,6 +239,12 @@ spec:
                   name: service-timeouts
                   key: TIMEOUTS_HMRCAPI_CONNECTMS
                   optional: true
+            - name: HMRC_SELFASSESSMENT_TAXYEARS_HISTORY_MAXIMUM
+              valueFrom:
+                configMapKeyRef:
+                  name: hmrc-service-config
+                  key: SELFASSESSMENT_TAXYEARS_HISTORY_MAXIMUM
+                  optional: true
           resources:
             limits:
               cpu: 1600m
@@ -272,7 +278,7 @@ spec:
             - mountPath: /etc/keystore
               name: keystore
               readOnly: true
-      
+
       volumes:
         - name: keystore
           emptyDir:


### PR DESCRIPTION
Added config for the Self Assessment Maximum Tax Year History variable in hmrc-service. It is optional since the code changes for EE-17546 add a default value (no limit to history) if the value is missing. I will add the configmaps before this is tested, and the PR should be tested before it is merged to master.