### PR TITLE
EE-32216: Specify a large startup delay for the liveness probe. It ma…

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -215,7 +215,7 @@ spec:
               httpHeaders:
                 - name: X-probe
                   value: kubelet
-            initialDelaySeconds: 10
+            initialDelaySeconds: 240
             periodSeconds: 20
             timeoutSeconds: 10
           readinessProbe:


### PR DESCRIPTION
…y be possible for this to be reduced if the truststore preparation is performed in an initcontainer.